### PR TITLE
Add MediaKeyFilter console app to filter media keys for WebView2

### DIFF
--- a/MediaKeyFilter/MediaKeyFilter.csproj
+++ b/MediaKeyFilter/MediaKeyFilter.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWinRT>true</UseWinRT>
+    <PlatformTarget>x64</PlatformTarget>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WindowsMediaController\WindowsMediaController.csproj" />
+  </ItemGroup>
+</Project>

--- a/MediaKeyFilter/Program.cs
+++ b/MediaKeyFilter/Program.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using WindowsMediaController;
+
+static class Program
+{
+    private static readonly MediaManager mediaManager = new();
+    private static MediaManager.MediaSession? lastAllowedSession;
+    private static readonly NativeMethods.LowLevelKeyboardProc hookProc = HookCallback;
+    private static IntPtr hookId = IntPtr.Zero;
+    private static readonly ManualResetEvent exitEvent = new(false);
+
+    static void Main()
+    {
+        mediaManager.Start();
+        hookId = NativeMethods.SetHook(hookProc);
+
+        Console.CancelKeyPress += (_, e) => { e.Cancel = true; exitEvent.Set(); };
+        AppDomain.CurrentDomain.ProcessExit += (_, __) => Cleanup();
+
+        Console.WriteLine("MediaKeyFilter running. Press Ctrl+C to exit.");
+        exitEvent.WaitOne();
+        Cleanup();
+    }
+
+    private static void Cleanup()
+    {
+        if (hookId != IntPtr.Zero)
+        {
+            NativeMethods.UnhookWindowsHookEx(hookId);
+            hookId = IntPtr.Zero;
+        }
+        mediaManager.Dispose();
+    }
+
+    private static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode >= 0 && wParam == (IntPtr)NativeMethods.WM_KEYDOWN)
+        {
+            int vkCode = Marshal.ReadInt32(lParam);
+            if (vkCode == NativeMethods.VK_MEDIA_PLAY_PAUSE ||
+                vkCode == NativeMethods.VK_MEDIA_NEXT_TRACK ||
+                vkCode == NativeMethods.VK_MEDIA_PREV_TRACK)
+            {
+                var focused = mediaManager.GetFocusedSession();
+                var exeName = focused != null ? Path.GetFileName(focused.Id) : "<none>";
+
+                if (focused != null && exeName.Equals("msedgewebview2.exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"Blocked {exeName} {vkCode}");
+                    if (lastAllowedSession != null)
+                    {
+                        SendCommand(lastAllowedSession, vkCode);
+                    }
+                    return (IntPtr)1;
+                }
+                else
+                {
+                    if (focused != null)
+                        lastAllowedSession = focused;
+                    Console.WriteLine($"Passed {exeName} {vkCode}");
+                }
+            }
+        }
+        return NativeMethods.CallNextHookEx(hookId, nCode, wParam, lParam);
+    }
+
+    private static void SendCommand(MediaManager.MediaSession session, int vk)
+    {
+        switch (vk)
+        {
+            case NativeMethods.VK_MEDIA_PLAY_PAUSE:
+                _ = session.ControlSession.TryPlayPauseAsync();
+                break;
+            case NativeMethods.VK_MEDIA_NEXT_TRACK:
+                _ = session.ControlSession.TrySkipNextAsync();
+                break;
+            case NativeMethods.VK_MEDIA_PREV_TRACK:
+                _ = session.ControlSession.TrySkipPreviousAsync();
+                break;
+        }
+    }
+
+    private static class NativeMethods
+    {
+        public const int VK_MEDIA_NEXT_TRACK = 0xB0;
+        public const int VK_MEDIA_PREV_TRACK = 0xB1;
+        public const int VK_MEDIA_PLAY_PAUSE = 0xB3;
+        public const int WM_KEYDOWN = 0x0100;
+        private const int WH_KEYBOARD_LL = 13;
+
+        public delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+        public static IntPtr SetHook(LowLevelKeyboardProc proc)
+        {
+            using var curProcess = Process.GetCurrentProcess();
+            using var curModule = curProcess.MainModule!;
+            return SetWindowsHookEx(WH_KEYBOARD_LL, proc, GetModuleHandle(curModule.ModuleName), 0);
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
+    }
+}
+

--- a/WindowsMediaController.sln
+++ b/WindowsMediaController.sln
@@ -15,6 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.UI", "Sample.UI\Samp
 		{C719D9AD-7724-47B7-90B7-20EF3C8EB6B5} = {C719D9AD-7724-47B7-90B7-20EF3C8EB6B5}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediaKeyFilter", "MediaKeyFilter\MediaKeyFilter.csproj", "{0B95FAEB-6629-4582-AD6F-5832F71E7811}"
+        ProjectSection(ProjectDependencies) = postProject
+                {C719D9AD-7724-47B7-90B7-20EF3C8EB6B5} = {C719D9AD-7724-47B7-90B7-20EF3C8EB6B5}
+        EndProjectSection
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AFE80E2D-35FF-497A-8057-E21625AA0C3D}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -38,7 +43,11 @@ Global
 		{0454D061-7BAB-4A24-995C-6FC5DC90CC55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0454D061-7BAB-4A24-995C-6FC5DC90CC55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0454D061-7BAB-4A24-995C-6FC5DC90CC55}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {0B95FAEB-6629-4582-AD6F-5832F71E7811}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0B95FAEB-6629-4582-AD6F-5832F71E7811}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0B95FAEB-6629-4582-AD6F-5832F71E7811}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0B95FAEB-6629-4582-AD6F-5832F71E7811}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- Add `MediaKeyFilter` .NET 6 console app that hooks global media keys
- Block media keys when `msedgewebview2.exe` is the focused SMTC session and optionally forward commands to last allowed session
- Wire new project into solution targeting x64 with WinRT

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689baa545df8832da5f4c2390978d9c2