### PR TITLE
Handle Bluetooth media buttons via raw input

### DIFF
--- a/MediaKeyFilter/Program.cs
+++ b/MediaKeyFilter/Program.cs
@@ -1,71 +1,106 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
 using WindowsMediaController;
 
 static class Program
 {
     private static readonly MediaManager mediaManager = new();
     private static MediaManager.MediaSession? lastAllowedSession;
-    private static readonly NativeMethods.LowLevelKeyboardProc hookProc = HookCallback;
-    private static IntPtr hookId = IntPtr.Zero;
-    private static readonly ManualResetEvent exitEvent = new(false);
+    private static IntPtr hwnd;
 
     static void Main()
     {
         mediaManager.Start();
-        hookId = NativeMethods.SetHook(hookProc);
 
-        Console.CancelKeyPress += (_, e) => { e.Cancel = true; exitEvent.Set(); };
+        hwnd = NativeMethods.GetConsoleWindow();
+
+        // Register media keys as global hotkeys so we can intercept them before SMTC
+        NativeMethods.RegisterHotKey(hwnd, 1, 0, NativeMethods.VK_MEDIA_PLAY_PAUSE);
+        NativeMethods.RegisterHotKey(hwnd, 2, 0, NativeMethods.VK_MEDIA_NEXT_TRACK);
+        NativeMethods.RegisterHotKey(hwnd, 3, 0, NativeMethods.VK_MEDIA_PREV_TRACK);
+
+        // Register for raw HID input (e.g. Bluetooth remotes) and suppress legacy handling
+        var rid = new NativeMethods.RAWINPUTDEVICE[]
+        {
+            new NativeMethods.RAWINPUTDEVICE
+            {
+                usUsagePage = NativeMethods.HID_USAGE_PAGE_CONSUMER,
+                usUsage = NativeMethods.HID_USAGE_CONSUMER_CONTROL,
+                dwFlags = NativeMethods.RIDEV_INPUTSINK | NativeMethods.RIDEV_NOLEGACY,
+                hwndTarget = hwnd
+            }
+        };
+        NativeMethods.RegisterRawInputDevices(rid, (uint)rid.Length, (uint)Marshal.SizeOf<NativeMethods.RAWINPUTDEVICE>());
+
+        Console.CancelKeyPress += (_, e) => { e.Cancel = true; NativeMethods.PostQuitMessage(0); };
         AppDomain.CurrentDomain.ProcessExit += (_, __) => Cleanup();
 
         Console.WriteLine("MediaKeyFilter running. Press Ctrl+C to exit.");
-        exitEvent.WaitOne();
+
+        NativeMethods.MSG msg;
+        while (NativeMethods.GetMessage(out msg, IntPtr.Zero, 0, 0))
+        {
+            if (msg.message == NativeMethods.WM_HOTKEY)
+            {
+                HandleKey(msg.wParam.ToInt32());
+            }
+            else if (msg.message == NativeMethods.WM_INPUT)
+            {
+                HandleRawInput(msg.lParam);
+            }
+            else
+            {
+                NativeMethods.TranslateMessage(ref msg);
+                NativeMethods.DispatchMessage(ref msg);
+            }
+        }
+
         Cleanup();
+    }
+
+    private static void HandleKey(int id)
+    {
+        int vk = id switch
+        {
+            1 => NativeMethods.VK_MEDIA_PLAY_PAUSE,
+            2 => NativeMethods.VK_MEDIA_NEXT_TRACK,
+            3 => NativeMethods.VK_MEDIA_PREV_TRACK,
+            _ => 0
+        };
+        if (vk == 0)
+            return;
+
+        var focused = mediaManager.GetFocusedSession();
+        var exeName = focused != null ? Path.GetFileName(focused.Id) : "<none>";
+
+        if (focused != null && exeName.Equals("msedgewebview2.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"Blocked {exeName} {vk}");
+            if (lastAllowedSession != null)
+            {
+                SendCommand(lastAllowedSession, vk);
+            }
+        }
+        else if (focused != null)
+        {
+            lastAllowedSession = focused;
+            Console.WriteLine($"Passed {exeName} {vk}");
+            SendCommand(focused, vk);
+        }
+        else if (lastAllowedSession != null)
+        {
+            Console.WriteLine($"No focused session, forwarding {vk}");
+            SendCommand(lastAllowedSession, vk);
+        }
     }
 
     private static void Cleanup()
     {
-        if (hookId != IntPtr.Zero)
-        {
-            NativeMethods.UnhookWindowsHookEx(hookId);
-            hookId = IntPtr.Zero;
-        }
+        NativeMethods.UnregisterHotKey(hwnd, 1);
+        NativeMethods.UnregisterHotKey(hwnd, 2);
+        NativeMethods.UnregisterHotKey(hwnd, 3);
         mediaManager.Dispose();
-    }
-
-    private static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
-    {
-        if (nCode >= 0 && wParam == (IntPtr)NativeMethods.WM_KEYDOWN)
-        {
-            int vkCode = Marshal.ReadInt32(lParam);
-            if (vkCode == NativeMethods.VK_MEDIA_PLAY_PAUSE ||
-                vkCode == NativeMethods.VK_MEDIA_NEXT_TRACK ||
-                vkCode == NativeMethods.VK_MEDIA_PREV_TRACK)
-            {
-                var focused = mediaManager.GetFocusedSession();
-                var exeName = focused != null ? Path.GetFileName(focused.Id) : "<none>";
-
-                if (focused != null && exeName.Equals("msedgewebview2.exe", StringComparison.OrdinalIgnoreCase))
-                {
-                    Console.WriteLine($"Blocked {exeName} {vkCode}");
-                    if (lastAllowedSession != null)
-                    {
-                        SendCommand(lastAllowedSession, vkCode);
-                    }
-                    return (IntPtr)1;
-                }
-                else
-                {
-                    if (focused != null)
-                        lastAllowedSession = focused;
-                    Console.WriteLine($"Passed {exeName} {vkCode}");
-                }
-            }
-        }
-        return NativeMethods.CallNextHookEx(hookId, nCode, wParam, lParam);
     }
 
     private static void SendCommand(MediaManager.MediaSession session, int vk)
@@ -88,36 +123,113 @@ static class Program
         }
     }
 
+    private static void HandleRawInput(IntPtr hRawInput)
+    {
+        uint dwSize = 0;
+        NativeMethods.GetRawInputData(hRawInput, NativeMethods.RID_INPUT, IntPtr.Zero, ref dwSize, (uint)Marshal.SizeOf<NativeMethods.RAWINPUTHEADER>());
+        IntPtr buffer = Marshal.AllocHGlobal((int)dwSize);
+        try
+        {
+            if (NativeMethods.GetRawInputData(hRawInput, NativeMethods.RID_INPUT, buffer, ref dwSize, (uint)Marshal.SizeOf<NativeMethods.RAWINPUTHEADER>()) != dwSize)
+                return;
+
+            var header = Marshal.PtrToStructure<NativeMethods.RAWINPUTHEADER>(buffer);
+            if (header.dwType != NativeMethods.RIM_TYPEHID)
+                return;
+
+            IntPtr pHid = buffer + Marshal.SizeOf<NativeMethods.RAWINPUTHEADER>();
+            uint sizeHid = (uint)Marshal.ReadInt32(pHid);
+            uint count = (uint)Marshal.ReadInt32(pHid, 4);
+            IntPtr pData = pHid + 8;
+
+            byte[] raw = new byte[sizeHid * count];
+            Marshal.Copy(pData, raw, 0, raw.Length);
+
+            for (int i = 0; i < count; i++)
+            {
+                ushort usage = BitConverter.ToUInt16(raw, i * (int)sizeHid);
+                switch (usage)
+                {
+                    case NativeMethods.HID_USAGE_PLAY_PAUSE:
+                        HandleKey(1);
+                        break;
+                    case NativeMethods.HID_USAGE_NEXT:
+                        HandleKey(2);
+                        break;
+                    case NativeMethods.HID_USAGE_PREV:
+                        HandleKey(3);
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
 
     private static class NativeMethods
     {
         public const int VK_MEDIA_NEXT_TRACK = 0xB0;
         public const int VK_MEDIA_PREV_TRACK = 0xB1;
         public const int VK_MEDIA_PLAY_PAUSE = 0xB3;
-        public const int WM_KEYDOWN = 0x0100;
-        private const int WH_KEYBOARD_LL = 13;
+        public const int WM_HOTKEY = 0x0312;
+        public const int WM_INPUT = 0x00FF;
+        public const uint RID_INPUT = 0x10000003;
+        public const uint RIM_TYPEHID = 2;
+        public const ushort HID_USAGE_PAGE_CONSUMER = 0x0C;
+        public const ushort HID_USAGE_CONSUMER_CONTROL = 0x01;
+        public const ushort HID_USAGE_PLAY_PAUSE = 0xCD;
+        public const ushort HID_USAGE_NEXT = 0xB5;
+        public const ushort HID_USAGE_PREV = 0xB6;
+        public const uint RIDEV_INPUTSINK = 0x00000100;
+        public const uint RIDEV_NOLEGACY = 0x00000030;
 
-        public delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
-
-        public static IntPtr SetHook(LowLevelKeyboardProc proc)
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT
         {
-            using var curProcess = Process.GetCurrentProcess();
-            using var curModule = curProcess.MainModule!;
-            return SetWindowsHookEx(WH_KEYBOARD_LL, proc, GetModuleHandle(curModule.ModuleName), 0);
+            public int x;
+            public int y;
         }
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MSG
+        {
+            public IntPtr hwnd;
+            public uint message;
+            public IntPtr wParam;
+            public IntPtr lParam;
+            public uint time;
+            public POINT pt;
+            public uint lPrivate;
+        }
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RAWINPUTDEVICE
+        {
+            public ushort usUsagePage;
+            public ushort usUsage;
+            public uint dwFlags;
+            public IntPtr hwndTarget;
+        }
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RAWINPUTHEADER
+        {
+            public uint dwType;
+            public uint dwSize;
+            public IntPtr hDevice;
+            public IntPtr wParam;
+        }
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr GetModuleHandle(string lpModuleName);
+        [DllImport("user32.dll")] public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, int vk);
+        [DllImport("user32.dll")] public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+        [DllImport("user32.dll")] public static extern bool GetMessage(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+        [DllImport("user32.dll")] public static extern bool TranslateMessage([In] ref MSG lpMsg);
+        [DllImport("user32.dll")] public static extern IntPtr DispatchMessage([In] ref MSG lpMsg);
+        [DllImport("user32.dll")] public static extern void PostQuitMessage(int nExitCode);
+        [DllImport("user32.dll")] public static extern bool RegisterRawInputDevices(RAWINPUTDEVICE[] pRawInputDevices, uint uiNumDevices, uint cbSize);
+        [DllImport("user32.dll")] public static extern uint GetRawInputData(IntPtr hRawInput, uint uiCommand, IntPtr pData, ref uint pcbSize, uint cbSizeHeader);
+        [DllImport("kernel32.dll")] public static extern IntPtr GetConsoleWindow();
     }
 }
-


### PR DESCRIPTION
## Summary
- intercept HID media buttons from devices like Bluetooth earbuds using raw input
- forward play/pause, next, and previous commands after filtering msedgewebview2 sessions

## Testing
- `dotnet restore MediaKeyFilter/MediaKeyFilter.csproj -p:TargetFramework=net6.0-windows10.0.19041.0 -p:TargetFrameworks=net6.0-windows10.0.19041.0 -p:EnableWindowsTargeting=true`
- `dotnet build MediaKeyFilter/MediaKeyFilter.csproj -p:TargetFramework=net6.0-windows10.0.19041.0 -p:TargetFrameworks=net6.0-windows10.0.19041.0 -p:EnableWindowsTargeting=true --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_689bba66d6e0832d9d65a2f71e1301dc